### PR TITLE
Backport PJProject changeset 4973

### DIFF
--- a/pjlib/include/pj/ssl_sock.h
+++ b/pjlib/include/pj/ssl_sock.h
@@ -202,6 +202,31 @@ PJ_DECL(pj_status_t) pj_ssl_cert_load_from_files(pj_pool_t *pool,
 						 const pj_str_t *privkey_pass,
 						 pj_ssl_cert_t **p_cert);
 
+/**
+ * Create credential from files.
+ *
+ * This is the same as pj_ssl_cert_load_from_files() but also
+ * accepts an additional param CA_path to load CA certificates from
+ * a directory.
+ *
+ * @param CA_file	The file of trusted CA list.
+ * @param CA_path	The path to a directory of trusted CA list.
+ * @param cert_file	The file of certificate.
+ * @param privkey_file	The file of private key.
+ * @param privkey_pass	The password of private key, if any.
+ * @param p_cert	Pointer to credential instance to be created.
+ *
+ * @return		PJ_SUCCESS when successful.
+ */
+PJ_DECL(pj_status_t) pj_ssl_cert_load_from_files2(
+						pj_pool_t *pool,
+						const pj_str_t *CA_file,
+						const pj_str_t *CA_path,
+						const pj_str_t *cert_file,
+						const pj_str_t *privkey_file,
+						const pj_str_t *privkey_pass,
+						pj_ssl_cert_t **p_cert);
+
 
 /**
  * Dump SSL certificate info.

--- a/pjlib/src/pj/ssl_sock_ossl.c
+++ b/pjlib/src/pj/ssl_sock_ossl.c
@@ -189,6 +189,7 @@ struct pj_ssl_sock_t
 struct pj_ssl_cert_t
 {
     pj_str_t CA_file;
+    pj_str_t CA_path;
     pj_str_t cert_file;
     pj_str_t privkey_file;
     pj_str_t privkey_pass;
@@ -548,14 +549,25 @@ static pj_status_t create_ssl(pj_ssl_sock_t *ssock)
     /* Apply credentials */
     if (cert) {
 	/* Load CA list if one is specified. */
-	if (cert->CA_file.slen) {
+	if (cert->CA_file.slen || cert->CA_path.slen) {
 
-	    rc = SSL_CTX_load_verify_locations(ctx, cert->CA_file.ptr, NULL);
+	    rc = SSL_CTX_load_verify_locations(
+			ctx,
+			cert->CA_file.slen == 0 ? NULL : cert->CA_file.ptr,
+			cert->CA_path.slen == 0 ? NULL : cert->CA_path.ptr);
 
 	    if (rc != 1) {
 		status = GET_SSL_STATUS(ssock);
-		PJ_LOG(1,(ssock->pool->obj_name, "Error loading CA list file "
-			  "'%s'", cert->CA_file.ptr));
+		if (cert->CA_file.slen) {
+		    PJ_LOG(1,(ssock->pool->obj_name,
+			      "Error loading CA list file '%s'",
+			      cert->CA_file.ptr));
+		}
+		if (cert->CA_path.slen) {
+		    PJ_LOG(1,(ssock->pool->obj_name,
+			      "Error loading CA path '%s'",
+			      cert->CA_path.ptr));
+		}
 		SSL_CTX_free(ctx);
 		return status;
 	    }
@@ -1895,12 +1907,31 @@ PJ_DEF(pj_status_t) pj_ssl_cert_load_from_files (pj_pool_t *pool,
 						 const pj_str_t *privkey_pass,
 						 pj_ssl_cert_t **p_cert)
 {
+    return pj_ssl_cert_load_from_files2(pool, CA_file, NULL, cert_file,
+					privkey_file, privkey_pass, p_cert);
+}
+
+PJ_DEF(pj_status_t) pj_ssl_cert_load_from_files2(pj_pool_t *pool,
+						 const pj_str_t *CA_file,
+						 const pj_str_t *CA_path,
+						 const pj_str_t *cert_file,
+						 const pj_str_t *privkey_file,
+						 const pj_str_t *privkey_pass,
+						 pj_ssl_cert_t **p_cert)
+{
     pj_ssl_cert_t *cert;
 
-    PJ_ASSERT_RETURN(pool && CA_file && cert_file && privkey_file, PJ_EINVAL);
+    PJ_ASSERT_RETURN(pool && (CA_file || CA_path) && cert_file &&
+		     privkey_file,
+		     PJ_EINVAL);
 
     cert = PJ_POOL_ZALLOC_T(pool, pj_ssl_cert_t);
-    pj_strdup_with_null(pool, &cert->CA_file, CA_file);
+    if (CA_file) {
+    	pj_strdup_with_null(pool, &cert->CA_file, CA_file);
+    }
+    if (CA_path) {
+    	pj_strdup_with_null(pool, &cert->CA_path, CA_path);
+    }
     pj_strdup_with_null(pool, &cert->cert_file, cert_file);
     pj_strdup_with_null(pool, &cert->privkey_file, privkey_file);
     pj_strdup_with_null(pool, &cert->privkey_pass, privkey_pass);
@@ -1924,6 +1955,7 @@ PJ_DECL(pj_status_t) pj_ssl_sock_set_certificate(
     cert_ = PJ_POOL_ZALLOC_T(pool, pj_ssl_cert_t);
     pj_memcpy(cert_, cert, sizeof(cert));
     pj_strdup_with_null(pool, &cert_->CA_file, &cert->CA_file);
+    pj_strdup_with_null(pool, &cert_->CA_path, &cert->CA_path);
     pj_strdup_with_null(pool, &cert_->cert_file, &cert->cert_file);
     pj_strdup_with_null(pool, &cert_->privkey_file, &cert->privkey_file);
     pj_strdup_with_null(pool, &cert_->privkey_pass, &cert->privkey_pass);

--- a/pjlib/src/pj/ssl_sock_symbian.cpp
+++ b/pjlib/src/pj/ssl_sock_symbian.cpp
@@ -859,8 +859,21 @@ PJ_DEF(pj_status_t) pj_ssl_cert_load_from_files(pj_pool_t *pool,
                                         	const pj_str_t *privkey_pass,
                                         	pj_ssl_cert_t **p_cert)
 {
+    return pj_ssl_cert_load_from_files2(pool, CA_file, NULL, cert_file,
+					privkey_file, privkey_pass, p_cert);
+}
+
+PJ_DEF(pj_status_t) pj_ssl_cert_load_from_files2(pj_pool_t *pool,
+                                        	 const pj_str_t *CA_file,
+                                        	 const pj_str_t *CA_path,
+                                        	 const pj_str_t *cert_file,
+                                        	 const pj_str_t *privkey_file,
+                                        	 const pj_str_t *privkey_pass,
+                                        	 pj_ssl_cert_t **p_cert)
+{
     PJ_UNUSED_ARG(pool);
     PJ_UNUSED_ARG(CA_file);
+    PJ_UNUSED_ARG(CA_path);
     PJ_UNUSED_ARG(cert_file);
     PJ_UNUSED_ARG(privkey_file);
     PJ_UNUSED_ARG(privkey_pass);

--- a/pjsip/include/pjsip/sip_transport_tls.h
+++ b/pjsip/include/pjsip/sip_transport_tls.h
@@ -75,6 +75,11 @@ typedef struct pjsip_tls_setting
     pj_str_t	ca_list_file;
 
     /**
+     * Certificate of Authority (CA) list directory path.
+     */
+    pj_str_t	ca_list_path;
+
+    /**
      * Public endpoint certificate file, which will be used as client-
      * side  certificate for outgoing TLS connection, and server-side
      * certificate for incoming TLS connection.

--- a/pjsip/src/pjsip/sip_transport_tls.c
+++ b/pjsip/src/pjsip/sip_transport_tls.c
@@ -421,10 +421,12 @@ PJ_DEF(pj_status_t) pjsip_tls_transport_start2( pjsip_endpoint *endpt,
 
     /* Check if certificate/CA list for SSL socket is set */
     if (listener->tls_setting.cert_file.slen ||
-	listener->tls_setting.ca_list_file.slen) 
+	listener->tls_setting.ca_list_file.slen ||
+	listener->tls_setting.ca_list_path.slen) 
     {
-	status = pj_ssl_cert_load_from_files(pool,
+	status = pj_ssl_cert_load_from_files2(pool,
 			&listener->tls_setting.ca_list_file,
+			&listener->tls_setting.ca_list_path,
 			&listener->tls_setting.cert_file,
 			&listener->tls_setting.privkey_file,
 			&listener->tls_setting.password,


### PR DESCRIPTION
This adds CA path support to PJLIB's securet
sockets. This was added as a direct result of
ASTERISK-24575